### PR TITLE
fix type to allow passing url string to an audio file

### DIFF
--- a/src/resources/audio/transcriptions.ts
+++ b/src/resources/audio/transcriptions.ts
@@ -116,7 +116,7 @@ export interface TranscriptionCreateParams {
   /**
    * Audio file to transcribe
    */
-  file: Uploadable;
+  file: Uploadable | string;
 
   /**
    * Optional ISO 639-1 language code. If `auto` is provided, language is

--- a/src/resources/audio/translations.ts
+++ b/src/resources/audio/translations.ts
@@ -115,7 +115,7 @@ export interface TranslationCreateParams {
   /**
    * Audio file to translate
    */
-  file: Uploadable;
+  file: Uploadable | string;
 
   /**
    * Target output language. Optional ISO 639-1 language code. If omitted, language


### PR DESCRIPTION
a string for a url to an audio file is also valid here and supported by the platform. it also works in the sdk if you use `@ts-expect-error` but we should correct the type