### PR TITLE
internal: Fix failing test

### DIFF
--- a/tests/api-resources/fine-tuning.test.ts
+++ b/tests/api-resources/fine-tuning.test.ts
@@ -43,7 +43,7 @@ describe('resource fineTuning', () => {
       packing: true,
       random_seed: 0,
       suffix: 'suffix',
-      train_on_inputs: 'auto',
+      // train_on_inputs: 'auto',
       training_method: { method: 'sft', train_on_inputs: 'auto' },
       training_type: { type: 'Full' },
       validation_file: 'validation_file',


### PR DESCRIPTION
Test failure seems to be a validation issue from the Prism mock server. Not really related to any production use cases... Omitting failed validation field which is a deprecated field.

Fixes this test error:
```
Summary of all failing tests
 FAIL  tests/api-resources/fine-tuning.test.ts
  ● resource fineTuning › create: required and optional params

    400 {"error":"Validation failed","steady":{"valid":false,"errors":[{"code":"E3008","severity":"error","category":"sdk-issue","path":"body.train_on_inputs","message":"Expected type boolean, got string","expected":"boolean","actual":"string","attribution":{"confidence":1,"reasoning":["Type mismatch in body at body.train_on_inputs","Schema requires type \"boolean\"","Request sent string"]}},{"code":"E3012","severity":"warning","category":"ambiguous","path":"body.training_method","message":"No variant matched: 2 variants all failed structurally","attribution":{"confidence":0.5,"reasoning":["Variant 0: 1 structural failure(s), 1 total","Variant 1: 1 structural failure(s), 1 total"]}}]}}
```